### PR TITLE
fix docker + webpack issue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,6 @@ Having trouble naming that pesky baby. Let us help! You can choose from our list
 
 **Docker**
 
-- Build image: docker build -t baby-namr .
-- Run container: docker run -p 3000:3000
-- http://localhost:3000
+- Build image: `docker build -t baby-namr .`
+- Run container: `docker run -p 3000:3000 baby-namr`
+- Visit `http://localhost:3000` in a browser

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -4,7 +4,8 @@ const baseConfig = require("./webpack.config.base");
 module.exports = merge(baseConfig, {
   mode: "development",
   devServer: {
-    port: 6969,
+    host: "0.0.0.0",
+    port: 3000,
   },
   devtool: "source-map",
 });


### PR DESCRIPTION
I found an issue that indicates that setting the host to `"0.0.0.0"` in the webpack config fixes the inaccessibility issue we encountered last Thursday. Works for me now - able to view the site on localhost:3000